### PR TITLE
[Misc] Allow find window with empty classname

### DIFF
--- a/UmaCruise/MainDlg.cpp
+++ b/UmaCruise/MainDlg.cpp
@@ -456,7 +456,14 @@ void CMainDlg::OnScreenShot(UINT uNotifyCode, int nID, CWindow wndCtl)
 		ChangeWindowTitle((LPCWSTR)title)
 			;
 	} else {
-		HWND hwndTarget = ::FindWindow(m_targetClassName, m_targetWindowName);
+		HWND hwndTarget = NULL;
+
+		if (m_targetClassName == "") {
+			hwndTarget = ::FindWindow(NULL, m_targetWindowName);
+		} else {
+			hwndTarget = ::FindWindow(m_targetClassName, m_targetWindowName);
+		}
+
 		if (!hwndTarget) {
 			ChangeWindowTitle(L"ウマ娘のウィンドウが見つかりません。。。");
 			return;

--- a/UmaCruise/UmaTextRecognizer.cpp
+++ b/UmaCruise/UmaTextRecognizer.cpp
@@ -210,7 +210,14 @@ bool UmaTextRecognizer::LoadSetting()
 
 std::unique_ptr<Gdiplus::Bitmap> UmaTextRecognizer::ScreenShot()
 {
-	CWindow hwndTarget = ::FindWindow(m_targetClassName, m_targetWindowName);
+	CWindow hwndTarget = NULL;
+
+	if (m_targetClassName == "") {
+		hwndTarget = ::FindWindow(NULL, m_targetWindowName);
+	} else {
+		hwndTarget = ::FindWindow(m_targetClassName, m_targetWindowName);
+	}
+
 	if (!hwndTarget) {
 		return nullptr;
 	}


### PR DESCRIPTION
Hello, This patch allow user left `Common.TargetWindow.ClassName` to empty string to find the window.
It make config more easier if target windows is not default.

It fix #15 

![image](https://user-images.githubusercontent.com/7088579/116808067-73f0aa80-ab69-11eb-823f-be42eec38007.png)
