### PR TITLE
ビルド時に GdiplusUtil.cpp の文字コード判別に失敗してエラーが出るので、コマンドラインオプションを追加

### DIFF
--- a/WindowsGraphicsCapture/WindowsGraphicsCapture.vcxproj
+++ b/WindowsGraphicsCapture/WindowsGraphicsCapture.vcxproj
@@ -130,6 +130,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -149,6 +150,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
当方の環境で（Visual Studio 2022 インストールしたてのほぼ素の状態です）
GdiplusUtil.cpp と GdiplusUtil.h が cp932 と判別されてビルドできなかったので、
UmaCruise.vcxproj に合わせてオプション（/source-charset:utf-8）を追加しました。

![スクリーンショット 2022-05-28 035716](https://user-images.githubusercontent.com/83184633/170782921-45080829-430b-4703-90fb-10940ea534b6.png)